### PR TITLE
Support `hreflang` attribute in ATOM `link` element

### DIFF
--- a/src/Atom/AtomConstants.cs
+++ b/src/Atom/AtomConstants.cs
@@ -14,6 +14,7 @@ static class AtomConstants
     public const string SpecificationLink = "http://atompub.org/2005/08/17/draft-ietf-atompub-format-11.html";
 
     public const string Href = "href";
+    public const string Hreflang = "hreflang";
     public const string Label = "label";
     public const string Length = "length";
     public const string Rel = "rel";

--- a/src/Atom/AtomFormatter.cs
+++ b/src/Atom/AtomFormatter.cs
@@ -412,6 +412,13 @@ public class AtomFormatter : ISyndicationFeedFormatter
         }
 
         //
+        // hreflang
+        if (!string.IsNullOrEmpty(link.Hreflang))
+        {
+            result.AddAttribute(new SyndicationAttribute(AtomConstants.Hreflang, link.Hreflang));
+        }
+
+        //
         // length
         if (link.Length > 0)
         {
@@ -459,7 +466,8 @@ public class AtomFormatter : ISyndicationFeedFormatter
         result.AddField(CreateFromLink(new SyndicationLink(link.Uri)
         {
             MediaType = link.MediaType,
-            Length = link.Length
+            Length = link.Length,
+            Hreflang = link.Hreflang
         }));
 
         //

--- a/src/Atom/AtomParser.cs
+++ b/src/Atom/AtomParser.cs
@@ -150,6 +150,10 @@ public class AtomParser : ISyndicationFeedParser
         long length = 0;
         TryParseValue(content.Attributes.GetAtom(AtomConstants.Length), out length);
 
+        // 
+        // hreflang
+        string hreflang = content.Attributes.GetAtom(AtomConstants.Hreflang);
+
         //
         // rel
         string rel = content.Attributes.GetAtom(AtomConstants.Rel) ?? ((content.Name == AtomElementNames.Link) ? AtomLinkTypes.Alternate : content.Name);
@@ -173,7 +177,8 @@ public class AtomParser : ISyndicationFeedParser
         {
             Title = title,
             Length = length,
-            MediaType = type
+            MediaType = type,
+            Hreflang = hreflang
         };
     }
 

--- a/src/ISyndicationLink.cs
+++ b/src/ISyndicationLink.cs
@@ -18,5 +18,7 @@ public interface ISyndicationLink
 
     long Length { get; }
 
+    string Hreflang { get; set; }
+
     DateTimeOffset LastUpdated { get; }
 }

--- a/src/SyndicationLink.cs
+++ b/src/SyndicationLink.cs
@@ -24,5 +24,7 @@ public sealed class SyndicationLink : ISyndicationLink
 
     public long Length { get; set; }
 
+    public string Hreflang { get; set; }
+
     public DateTimeOffset LastUpdated { get; set; }
 }

--- a/tests/AtomWriter.cs
+++ b/tests/AtomWriter.cs
@@ -108,6 +108,32 @@ public class AtomWriter
         Assert.True(CheckResult(res, $"<link title=\"{link.Title}\" href=\"{link.Uri}\" type=\"{link.MediaType}\" length=\"{link.Length}\" />"));
     }
 
+    [Fact]
+    public async Task WriteLinkWithHreflang()
+    {
+        var sw = new StringWriterWithEncoding(Encoding.UTF8);
+
+        var link = new SyndicationLink(new Uri("http://contoso.com"))
+        {
+            Title = "Test title",
+            Length = 123,
+            MediaType = "mp3/video",
+            Hreflang = "en"
+        };
+
+        using (var xmlWriter = XmlWriter.Create(sw))
+        {
+            var writer = new AtomFeedWriter(xmlWriter);
+
+            await writer.Write(link);
+
+            await writer.Flush();
+        }
+
+        string res = sw.ToString();
+        Assert.True(CheckResult(res, $"<link title=\"{link.Title}\" href=\"{link.Uri}\" type=\"{link.MediaType}\" hreflang=\"en\" length=\"{link.Length}\" />"));
+    }
+
 
     [Fact]
     public async Task WriteEntry()


### PR DESCRIPTION
Support `hreflang` for ATOM feed.

The `hreflang` tag is an HTML attribute that tells search engines the language and geographical targeting of a webpage. It's used to help search engines understand which version of a webpage to show users based on their language preferences and location.

`<link rel="alternate" type="text/html" hreflang="en" href="http://example.org/"/>`

Reference: [The Atom Syndication Format](https://www.ietf.org/rfc/rfc4287.txt)