### PR TITLE
Update xunit.runner.visualstudio to v3.1.4

### DIFF
--- a/tests/Edi.SyndicationFeed.ReaderWriter.Tests.csproj
+++ b/tests/Edi.SyndicationFeed.ReaderWriter.Tests.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Bumps the xunit.runner.visualstudio package version from 3.1.1 to 3.1.4 in the test project for improved compatibility and bug fixes.