### PR TITLE
Use modern C# language features

### DIFF
--- a/src/Atom/AtomFeedReader.cs
+++ b/src/Atom/AtomFeedReader.cs
@@ -32,13 +32,7 @@ public class AtomFeedReader(XmlReader reader, ISyndicationFeedParser parser) : X
 
     public virtual async Task<IAtomEntry> ReadEntry()
     {
-        IAtomEntry item = await base.ReadItem() as IAtomEntry;
-
-        if (item == null)
-        {
-            throw new FormatException("Invalid Atom entry");
-        }
-
+        IAtomEntry item = await base.ReadItem() as IAtomEntry ?? throw new FormatException("Invalid Atom entry");
         return item;
     }
 

--- a/src/Atom/AtomFeedReader.cs
+++ b/src/Atom/AtomFeedReader.cs
@@ -9,20 +9,14 @@ using System.Xml;
 
 namespace Edi.SyndicationFeed.ReaderWriter.Atom;
 
-public class AtomFeedReader : XmlFeedReader
+public class AtomFeedReader(XmlReader reader, ISyndicationFeedParser parser) : XmlFeedReader(reader, parser)
 {
-    private readonly XmlReader _reader;
+    private readonly XmlReader _reader = reader;
     private bool _knownFeed;
 
     public AtomFeedReader(XmlReader reader)
         : this(reader, new AtomParser())
     {
-    }
-
-    public AtomFeedReader(XmlReader reader, ISyndicationFeedParser parser)
-        : base(reader, parser)
-    {
-        _reader = reader;
     }
 
     public override async Task<bool> Read()

--- a/src/Atom/AtomFeedWriter.cs
+++ b/src/Atom/AtomFeedWriter.cs
@@ -23,7 +23,7 @@ public class AtomFeedWriter : XmlFeedWriter
     }
 
     public AtomFeedWriter(XmlWriter writer, IEnumerable<ISyndicationAttribute> attributes, ISyndicationFeedFormatter formatter) :
-        this(writer, formatter, EnsureXmlNs(attributes ?? Enumerable.Empty<ISyndicationAttribute>()))
+        this(writer, formatter, EnsureXmlNs(attributes ?? []))
     {
     }
 

--- a/src/Atom/AtomFeedWriter.cs
+++ b/src/Atom/AtomFeedWriter.cs
@@ -56,9 +56,9 @@ public class AtomFeedWriter : XmlFeedWriter
 
     public virtual Task WriteUpdated(DateTimeOffset dt)
     {
-        if (dt == default(DateTimeOffset))
+        if (dt == default)
         {
-            throw new ArgumentException(nameof(dt));
+            throw new ArgumentException(null, nameof(dt));
         }
 
         return WriteValue(AtomElementNames.Updated, dt);

--- a/src/Atom/AtomFormatter.cs
+++ b/src/Atom/AtomFormatter.cs
@@ -120,17 +120,12 @@ public class AtomFormatter : ISyndicationFeedFormatter
             throw new ArgumentNullException("Uri");
         }
 
-        switch (link.RelationshipType)
+        return link.RelationshipType switch
         {
-            case AtomLinkTypes.Content:
-                return CreateFromContentLink(link);
-
-            case AtomLinkTypes.Source:
-                return CreateFromSourceLink(link);
-
-            default:
-                return CreateFromLink(link);
-        }
+            AtomLinkTypes.Content => CreateFromContentLink(link),
+            AtomLinkTypes.Source => CreateFromSourceLink(link),
+            _ => CreateFromLink(link),
+        };
     }
 
     public virtual ISyndicationContent CreateContent(ISyndicationCategory category)

--- a/src/Atom/AtomFormatter.cs
+++ b/src/Atom/AtomFormatter.cs
@@ -239,7 +239,7 @@ public class AtomFormatter : ISyndicationFeedFormatter
             throw new ArgumentNullException("Title");
         }
 
-        if (item.LastUpdated == default(DateTimeOffset))
+        if (item.LastUpdated == default)
         {
             throw new ArgumentException("LastUpdated");
         }
@@ -260,7 +260,7 @@ public class AtomFormatter : ISyndicationFeedFormatter
 
         //
         // published
-        if (item.Published != default(DateTimeOffset))
+        if (item.Published != default)
         {
             result.AddField(new SyndicationContent(AtomElementNames.Published, FormatValue(item.Published)));
         }
@@ -467,7 +467,7 @@ public class AtomFormatter : ISyndicationFeedFormatter
 
         //
         // updated
-        if (link.LastUpdated != default(DateTimeOffset))
+        if (link.LastUpdated != default)
         {
             result.AddField(new SyndicationContent(AtomElementNames.Updated, FormatValue(link.LastUpdated)));
         }

--- a/src/Atom/AtomFormatter.cs
+++ b/src/Atom/AtomFormatter.cs
@@ -25,7 +25,7 @@ public class AtomFormatter : ISyndicationFeedFormatter
     {
         _buffer = new StringBuilder();
         _writer = XmlUtils.CreateXmlWriter(settings?.Clone() ?? new XmlWriterSettings(),
-            EnsureAtomNs(knownAttributes ?? Enumerable.Empty<ISyndicationAttribute>()),
+            EnsureAtomNs(knownAttributes ?? []),
             _buffer);
     }
 

--- a/src/Atom/AtomParser.cs
+++ b/src/Atom/AtomParser.cs
@@ -102,13 +102,7 @@ public class AtomParser : ISyndicationFeedParser
             throw new ArgumentNullException(nameof(content));
         }
 
-        string term = content.Attributes.GetAtom(AtomConstants.Term);
-
-        if (term == null)
-        {
-            throw new FormatException("Invalid Atom category, requires Term attribute");
-        }
-
+        string term = content.Attributes.GetAtom(AtomConstants.Term) ?? throw new FormatException("Invalid Atom category, requires Term attribute");
         return new SyndicationCategory(term)
         {
             Scheme = content.Attributes.GetAtom(AtomConstants.Scheme),

--- a/src/Edi.SyndicationFeed.ReaderWriter.csproj
+++ b/src/Edi.SyndicationFeed.ReaderWriter.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <Version>2.4.0</Version>
+        <Version>2.4.1</Version>
         <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
         <Company>Microsoft</Company>
         <Authors>Microsoft, Edi Wang</Authors>

--- a/src/Rss/RssFeedReader.cs
+++ b/src/Rss/RssFeedReader.cs
@@ -8,20 +8,14 @@ using System.Xml;
 
 namespace Edi.SyndicationFeed.ReaderWriter.Rss;
 
-public class RssFeedReader : XmlFeedReader
+public class RssFeedReader(XmlReader reader, ISyndicationFeedParser parser) : XmlFeedReader(reader, parser)
 {
-    private readonly XmlReader _reader;
+    private readonly XmlReader _reader = reader;
     private bool _knownFeed;
 
     public RssFeedReader(XmlReader reader)
         : this(reader, new RssParser())
     {
-    }
-
-    public RssFeedReader(XmlReader reader, ISyndicationFeedParser parser)
-        : base(reader, parser)
-    {
-        _reader = reader;
     }
 
     public override async Task<bool> Read()

--- a/src/Rss/RssFeedReader.cs
+++ b/src/Rss/RssFeedReader.cs
@@ -36,27 +36,15 @@ public class RssFeedReader(XmlReader reader, ISyndicationFeedParser parser) : Xm
             return SyndicationElementType.Content;
         }
 
-        switch (elementName)
+        return elementName switch
         {
-            case RssElementNames.Item:
-                return SyndicationElementType.Item;
-
-            case RssElementNames.Link:
-                return SyndicationElementType.Link;
-
-            case RssElementNames.Category:
-                return SyndicationElementType.Category;
-
-            case RssElementNames.Author:
-            case RssElementNames.ManagingEditor:
-                return SyndicationElementType.Person;
-
-            case RssElementNames.Image:
-                return SyndicationElementType.Image;
-
-            default:
-                return SyndicationElementType.Content;
-        }
+            RssElementNames.Item => SyndicationElementType.Item,
+            RssElementNames.Link => SyndicationElementType.Link,
+            RssElementNames.Category => SyndicationElementType.Category,
+            RssElementNames.Author or RssElementNames.ManagingEditor => SyndicationElementType.Person,
+            RssElementNames.Image => SyndicationElementType.Image,
+            _ => SyndicationElementType.Content,
+        };
     }
 
     private async Task InitRead()

--- a/src/Rss/RssFeedWriter.cs
+++ b/src/Rss/RssFeedWriter.cs
@@ -64,7 +64,7 @@ public class RssFeedWriter(XmlWriter writer, IEnumerable<ISyndicationAttribute> 
 
     public virtual Task WritePubDate(DateTimeOffset dt)
     {
-        if (dt == default(DateTimeOffset))
+        if (dt == default)
         {
             throw new ArgumentException(nameof(dt));
         }
@@ -74,7 +74,7 @@ public class RssFeedWriter(XmlWriter writer, IEnumerable<ISyndicationAttribute> 
 
     public virtual Task WriteLastBuildDate(DateTimeOffset dt)
     {
-        if (dt == default(DateTimeOffset))
+        if (dt == default)
         {
             throw new ArgumentException(nameof(dt));
         }
@@ -127,7 +127,7 @@ public class RssFeedWriter(XmlWriter writer, IEnumerable<ISyndicationAttribute> 
 
     public virtual Task WriteTimeToLive(TimeSpan ttl)
     {
-        if (ttl == default(TimeSpan))
+        if (ttl == default)
         {
             throw new ArgumentException(nameof(ttl));
         }

--- a/src/Rss/RssFeedWriter.cs
+++ b/src/Rss/RssFeedWriter.cs
@@ -11,22 +11,15 @@ using System.Xml;
 
 namespace Edi.SyndicationFeed.ReaderWriter.Rss;
 
-public class RssFeedWriter : XmlFeedWriter
+public class RssFeedWriter(XmlWriter writer, IEnumerable<ISyndicationAttribute> attributes, ISyndicationFeedFormatter formatter) : XmlFeedWriter(writer, formatter ?? new RssFormatter(attributes, writer.Settings))
 {
-    private readonly XmlWriter _writer;
+    private readonly XmlWriter _writer = writer;
     private bool _feedStarted;
-    private readonly IEnumerable<ISyndicationAttribute> _attributes;
+    private readonly IEnumerable<ISyndicationAttribute> _attributes = attributes;
 
     public RssFeedWriter(XmlWriter writer, IEnumerable<ISyndicationAttribute> attributes = null)
         : this(writer, attributes, null)
     {
-    }
-
-    public RssFeedWriter(XmlWriter writer, IEnumerable<ISyndicationAttribute> attributes, ISyndicationFeedFormatter formatter) :
-        base(writer, formatter ?? new RssFormatter(attributes, writer.Settings))
-    {
-        _writer = writer;
-        _attributes = attributes;
     }
 
     public virtual Task WriteTitle(string value)

--- a/src/Rss/RssFormatter.cs
+++ b/src/Rss/RssFormatter.cs
@@ -123,20 +123,13 @@ public class RssFormatter : ISyndicationFeedFormatter
             throw new ArgumentNullException("Invalid link uri");
         }
 
-        switch (link.RelationshipType)
+        return link.RelationshipType switch
         {
-            case RssElementNames.Enclosure:
-                return CreateEnclosureContent(link);
-
-            case RssElementNames.Comments:
-                return CreateCommentsContent(link);
-
-            case RssElementNames.Source:
-                return CreateSourceContent(link);
-
-            default:
-                return CreateLinkContent(link);
-        }
+            RssElementNames.Enclosure => CreateEnclosureContent(link),
+            RssElementNames.Comments => CreateCommentsContent(link),
+            RssElementNames.Source => CreateSourceContent(link),
+            _ => CreateLinkContent(link),
+        };
     }
 
     public virtual ISyndicationContent CreateContent(ISyndicationCategory category)

--- a/src/SyndicationAttribute.cs
+++ b/src/SyndicationAttribute.cs
@@ -6,21 +6,14 @@ using System;
 
 namespace Edi.SyndicationFeed.ReaderWriter;
 
-public sealed class SyndicationAttribute : ISyndicationAttribute
+public sealed class SyndicationAttribute(string name, string ns, string value) : ISyndicationAttribute
 {
     public SyndicationAttribute(string name, string value) :
         this(name, null, value)
     {
     }
 
-    public SyndicationAttribute(string name, string ns, string value)
-    {
-        Name = name ?? throw new ArgumentNullException(nameof(name));
-        Value = value ?? throw new ArgumentNullException(nameof(value));
-        Namespace = ns;
-    }
-
-    public string Name { get; }
-    public string Namespace { get; }
-    public string Value { get; }
+    public string Name { get; } = name ?? throw new ArgumentNullException(nameof(name));
+    public string Namespace { get; } = ns;
+    public string Value { get; } = value ?? throw new ArgumentNullException(nameof(value));
 }

--- a/src/SyndicationCategory.cs
+++ b/src/SyndicationCategory.cs
@@ -6,14 +6,9 @@ using System;
 
 namespace Edi.SyndicationFeed.ReaderWriter;
 
-public sealed class SyndicationCategory : ISyndicationCategory
+public sealed class SyndicationCategory(string name) : ISyndicationCategory
 {
-    public SyndicationCategory(string name)
-    {
-        Name = name ?? throw new ArgumentNullException(nameof(name));
-    }
-
-    public string Name { get; }
+    public string Name { get; } = name ?? throw new ArgumentNullException(nameof(name));
 
     public string Label { get; set; }
 

--- a/src/SyndicationContent.cs
+++ b/src/SyndicationContent.cs
@@ -30,8 +30,8 @@ public class SyndicationContent : ISyndicationContent
         Value = value;
         Namespace = ns;
 
-        _attributes = new List<ISyndicationAttribute>();
-        _children = new List<ISyndicationContent>();
+        _attributes = [];
+        _children = [];
     }
 
     public SyndicationContent(ISyndicationContent content)

--- a/src/SyndicationImage.cs
+++ b/src/SyndicationImage.cs
@@ -6,21 +6,15 @@ using System;
 
 namespace Edi.SyndicationFeed.ReaderWriter;
 
-public sealed class SyndicationImage : ISyndicationImage
+public sealed class SyndicationImage(Uri url, string relationshipType = null) : ISyndicationImage
 {
-    public SyndicationImage(Uri url, string relationshipType = null)
-    {
-        Url = url ?? throw new ArgumentNullException(nameof(url));
-        RelationshipType = relationshipType;
-    }
-
     public string Title { get; set; }
 
-    public Uri Url { get; }
+    public Uri Url { get; } = url ?? throw new ArgumentNullException(nameof(url));
 
     public ISyndicationLink Link { get; set; }
 
-    public string RelationshipType { get; set; }
+    public string RelationshipType { get; set; } = relationshipType;
 
     public string Description { get; set; }
 }

--- a/src/SyndicationItem.cs
+++ b/src/SyndicationItem.cs
@@ -16,9 +16,9 @@ public class SyndicationItem : ISyndicationItem
 
     public SyndicationItem()
     {
-        _categories = new List<ISyndicationCategory>();
-        _contributors = new List<ISyndicationPerson>();
-        _links = new List<ISyndicationLink>();
+        _categories = [];
+        _contributors = [];
+        _links = [];
     }
 
     public SyndicationItem(ISyndicationItem item)

--- a/src/SyndicationLink.cs
+++ b/src/SyndicationLink.cs
@@ -6,21 +6,15 @@ using System;
 
 namespace Edi.SyndicationFeed.ReaderWriter;
 
-public sealed class SyndicationLink : ISyndicationLink
+public sealed class SyndicationLink(Uri url, string relationshipType = null) : ISyndicationLink
 {
-    public SyndicationLink(Uri url, string relationshipType = null)
-    {
-        Uri = url ?? throw new ArgumentNullException(nameof(url));
-        RelationshipType = relationshipType;
-    }
-
-    public Uri Uri { get; }
+    public Uri Uri { get; } = url ?? throw new ArgumentNullException(nameof(url));
 
     public string Title { get; set; }
 
     public string MediaType { get; set; }
 
-    public string RelationshipType { get; }
+    public string RelationshipType { get; } = relationshipType;
 
     public long Length { get; set; }
 

--- a/src/Utils/Converter.cs
+++ b/src/Utils/Converter.cs
@@ -10,7 +10,7 @@ static class Converter
 {
     public static bool TryParseValue<T>(string value, out T result)
     {
-        result = default(T);
+        result = default;
 
         Type type = typeof(T);
 

--- a/src/XmlFeedReader.cs
+++ b/src/XmlFeedReader.cs
@@ -9,22 +9,14 @@ using System.Xml;
 
 namespace Edi.SyndicationFeed.ReaderWriter;
 
-public abstract class XmlFeedReader : ISyndicationFeedReader
+public abstract class XmlFeedReader(XmlReader reader, ISyndicationFeedParser parser) : ISyndicationFeedReader
 {
-    private readonly XmlReader _reader;
+    private readonly XmlReader _reader = reader ?? throw new ArgumentNullException(nameof(reader));
     private bool _currentSet;
 
-    protected XmlFeedReader(XmlReader reader, ISyndicationFeedParser parser)
-    {
-        _reader = reader ?? throw new ArgumentNullException(nameof(reader));
-        Parser = parser ?? throw new ArgumentNullException(nameof(parser));
+    public ISyndicationFeedParser Parser { get; } = parser ?? throw new ArgumentNullException(nameof(parser));
 
-        ElementType = SyndicationElementType.None;
-    }
-
-    public ISyndicationFeedParser Parser { get; }
-
-    public SyndicationElementType ElementType { get; private set; }
+    public SyndicationElementType ElementType { get; private set; } = SyndicationElementType.None;
 
     public string ElementName { get; private set; }
 

--- a/src/XmlFeedWriter.cs
+++ b/src/XmlFeedWriter.cs
@@ -9,17 +9,11 @@ using System.Xml;
 
 namespace Edi.SyndicationFeed.ReaderWriter;
 
-public abstract class XmlFeedWriter : ISyndicationFeedWriter
+public abstract class XmlFeedWriter(XmlWriter writer, ISyndicationFeedFormatter formatter) : ISyndicationFeedWriter
 {
-    private readonly XmlWriter _writer;
+    private readonly XmlWriter _writer = writer ?? throw new ArgumentNullException(nameof(writer));
 
-    protected XmlFeedWriter(XmlWriter writer, ISyndicationFeedFormatter formatter)
-    {
-        _writer = writer ?? throw new ArgumentNullException(nameof(writer));
-        Formatter = formatter ?? throw new ArgumentNullException(nameof(formatter));
-    }
-
-    public ISyndicationFeedFormatter Formatter { get; }
+    public ISyndicationFeedFormatter Formatter { get; } = formatter ?? throw new ArgumentNullException(nameof(formatter));
 
     public virtual Task Write(ISyndicationContent content)
     {

--- a/src/XmlFeedWriter.cs
+++ b/src/XmlFeedWriter.cs
@@ -52,13 +52,7 @@ public abstract class XmlFeedWriter(XmlWriter writer, ISyndicationFeedFormatter 
             throw new ArgumentNullException(nameof(name));
         }
 
-        string valueString = Formatter.FormatValue(value);
-
-        if (valueString == null)
-        {
-            throw new FormatException(nameof(value));
-        }
-
+        string valueString = Formatter.FormatValue(value) ?? throw new FormatException(nameof(value));
         return WriteRaw(Formatter.Format(new SyndicationContent(name, valueString)));
     }
 


### PR DESCRIPTION
This pull request refactors several classes in the Atom and RSS feed reader/writer libraries to use C# primary constructor syntax and modern language features, resulting in cleaner, more concise code. It also updates collection and default value initializations to leverage C# 9.0+ syntax, and replaces switch statements with switch expressions for improved readability. Additionally, some exception handling logic is streamlined for brevity.

### Refactoring to Primary Constructors and Modern Syntax

* Refactored classes such as `AtomFeedReader`, `RssFeedReader`, `RssFeedWriter`, `SyndicationAttribute`, `SyndicationCategory`, `SyndicationImage`, and `SyndicationLink` to use primary constructors, reducing boilerplate and making property initialization more concise. (`src/Atom/AtomFeedReader.cs` [[1]](diffhunk://#diff-4a424fec91c8fb1d3afc47d88306397bda57894f98e575aba7b5cbdf31d71a24L12-L27) `src/Rss/RssFeedReader.cs` [[2]](diffhunk://#diff-4490f5df9c1055c4224fb5a3f04a1f68ae90080b630ab163864ffd3ca4779557L11-L26) `src/Rss/RssFeedWriter.cs` [[3]](diffhunk://#diff-d7e45a33aef03b3d9a1554f937a4daa5b9a8aef2ff787ba437346a46ea3c13e7L14-L31) `src/SyndicationAttribute.cs` [[4]](diffhunk://#diff-9d966e8d9df2619897d4c552705dae635016d0a6568490ca33b547c27a46701dL9-R18) `src/SyndicationCategory.cs` [[5]](diffhunk://#diff-04f9c3658f0f19ffba60d1e6578a3d26ae60ac53fbcb9bd35ce8b2ecc5b925edL9-R11) `src/SyndicationImage.cs` [[6]](diffhunk://#diff-09f1fd182ac4146462c148ca22412665834e5747bb8b9e2b9b187f27be4369ebL9-R17) `src/SyndicationLink.cs` [[7]](diffhunk://#diff-5f252a135e20eb8ccbaed9655feaa3844fa20f9fcda55ae9edc9a2bd7cf318aaL9-R17) `src/XmlFeedReader.cs` [[8]](diffhunk://#diff-80590da325f7040f49c69580586cd33688671c9e9cec1fce325bd4f91549e947L12-R19) `src/XmlFeedWriter.cs` [[9]](diffhunk://#diff-8c7bbbc2fbd1fe818c24afcd3359ec804770db9e411808a3411d2e203d229a46L12-R16)

* Updated collection initializations to use array initializer syntax (`[]`) instead of explicit `new List<T>()`, and replaced `default(T)` with `default` for value initialization. (`src/SyndicationContent.cs` [[1]](diffhunk://#diff-088d873bc3ee866831c12c84500220524633b467280357b83acbd718cd01c7a1L33-R34) `src/SyndicationItem.cs` [[2]](diffhunk://#diff-3ea3d2906d2981915557b6ac8e2755205cc4efe585912dfaabf97b9f854be4a5L19-R21) `src/Atom/AtomFormatter.cs` [[3]](diffhunk://#diff-32d0ca67bd6a1e8976b21cd83c51223ca8e61ab6298f2c2c5a07c05e70dcfd34L28-R28) `src/Atom/AtomFeedWriter.cs` [[4]](diffhunk://#diff-444c6fc6c4b33af515e25de6f71e5aeb545c408565e33603c02fa916fffbf1acL26-R26) `src/Utils/Converter.cs` [[5]](diffhunk://#diff-8c3583aaced8da121ba82af04bbdb28659365cd2e0669791331087093551d6eaL13-R13)

### Improved Exception Handling and Validation

* Streamlined null-check and exception logic using null-coalescing assignment and simplified argument validation in constructors and methods. (`src/Atom/AtomParser.cs` [[1]](diffhunk://#diff-f8c00b19fcf29e94d2e733a561bde78628f8ddc803b9ec9671903bb5dbb710f2L105-R105) `src/Atom/AtomFeedReader.cs` [[2]](diffhunk://#diff-4a424fec91c8fb1d3afc47d88306397bda57894f98e575aba7b5cbdf31d71a24L41-R35)

### Switch Statement Modernization

* Replaced traditional switch statements with switch expressions for mapping element types and creating content, improving readability and maintainability. (`src/Atom/AtomFormatter.cs` [[1]](diffhunk://#diff-32d0ca67bd6a1e8976b21cd83c51223ca8e61ab6298f2c2c5a07c05e70dcfd34L123-R128) `src/Rss/RssFeedReader.cs` [[2]](diffhunk://#diff-4490f5df9c1055c4224fb5a3f04a1f68ae90080b630ab163864ffd3ca4779557L45-R47) `src/Rss/RssFormatter.cs` [[3]](diffhunk://#diff-14c519a550338eab08c8ff6cc92cf7e89dd4c51d430ffef347e32b6f01b386a6L126-R132)

### Consistent Default Value Checks

* Standardized default value checks by replacing `default(DateTimeOffset)` and similar constructs with `default`. (`src/Atom/AtomFeedWriter.cs` [[1]](diffhunk://#diff-444c6fc6c4b33af515e25de6f71e5aeb545c408565e33603c02fa916fffbf1acL59-R61) `src/Atom/AtomFormatter.cs` [[2]](diffhunk://#diff-32d0ca67bd6a1e8976b21cd83c51223ca8e61ab6298f2c2c5a07c05e70dcfd34L247-R242) [[3]](diffhunk://#diff-32d0ca67bd6a1e8976b21cd83c51223ca8e61ab6298f2c2c5a07c05e70dcfd34L268-R263) [[4]](diffhunk://#diff-32d0ca67bd6a1e8976b21cd83c51223ca8e61ab6298f2c2c5a07c05e70dcfd34L475-R470) `src/Rss/RssFeedWriter.cs` [[5]](diffhunk://#diff-d7e45a33aef03b3d9a1554f937a4daa5b9a8aef2ff787ba437346a46ea3c13e7L74-R67) [[6]](diffhunk://#diff-d7e45a33aef03b3d9a1554f937a4daa5b9a8aef2ff787ba437346a46ea3c13e7L84-R77) [[7]](diffhunk://#diff-d7e45a33aef03b3d9a1554f937a4daa5b9a8aef2ff787ba437346a46ea3c13e7L137-R130)

### Version Update

* Updated project version from `2.4.0` to `2.4.1` in `src/Edi.SyndicationFeed.ReaderWriter.csproj` to reflect these changes.